### PR TITLE
added pip install and fixed output directory for notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # whizard-pythia-delphes
 Docker-based setup to run Whizard, Pythia and Delphes simulation.
 
+## Install requirements
+First, ensure you have installed some useful packages
+```
+pip install -r requirements.txt
+```
 ## Run Whizard cross-section calculation for HH at Muon Collider
 In order to run a simple Whizard-based cross-section calculation for HH at the muon-collider, you can execute this command:
 ```

--- a/notebooks/mumu_HH_xs.ipynb
+++ b/notebooks/mumu_HH_xs.ipynb
@@ -54,7 +54,7 @@
     "import os\n",
     "import re\n",
     "\n",
-    "whizard_dirs = sorted(glob('../files/output/whizard/mumu_HH_xs_restr/*'))\n",
+    "whizard_dirs = sorted(glob('../files/output/whizard/mumu_HH_xs_restr_lhe/*'))\n",
     "p(whizard_dirs)"
    ]
   },


### PR DESCRIPTION
I added pip install -r requirements.txt to the README.md 

I also noticed the notebook output-of-the-box did not work - as the output folder structure had a _lhe appended. 

It now works correctly 